### PR TITLE
Branch mass assign

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -17,26 +17,27 @@ import seedu.address.model.person.Person;
  */
 public class AssignCommand extends Command {
     public static final String COMMAND_WORD = "assign";
-    public static final String MESSAGE_USAGE = String.format(
-            "%s: Assign a duty date to personnel by specifying the identity of the personnel. "
+    public static final String MESSAGE_USAGE = String.format("%s: Assign a duty date to personnel(s) identified "
+                    + "by the index number used in the displayed person list. "
                     + "Duplicate dates will be considered the same.\n"
-                    + "Parameters: INDEX, %sDUTY_DATE\n"
-                    + "Example: assign 1 d/2025-04-15",
+                    + "Parameters: INDEX(S), %sDUTY_DATE\n"
+                    + "Example: assign 1 d/2025-04-15\n"
+                    + "Example: assign 1 2 3 d/2025-04-15",
             COMMAND_WORD, CliSyntax.PREFIX_DUTY);
-    public static final String MESSAGE_ASSIGN_DUTY_SUCCESS =
-            "Success! Duty assigned to person %1$s!";
+    public static final String MESSAGE_ASSIGN_DUTY_SUCCESS = "Success! Duty assigned to person %1$s!";
+    public static final String MESSAGE_MASS_ASSIGN_DUTY_SUCCESS = "Success! Duty assigned to %1$s persons!";
 
-    private final Index index;
+    private final List<Index> indexList;
     private final String dutyDate;
 
     /**
-     * @param index the index of the personnel to assign duty
+     * @param indexList the index of the personnel to assign duty
      * @param dutyDate the string representation of the duty dates
      */
-    public AssignCommand(Index index, String dutyDate) {
-        requireAllNonNull(index, dutyDate);
+    public AssignCommand(List<Index> indexList, String dutyDate) {
+        requireAllNonNull(indexList, dutyDate);
 
-        this.index = index;
+        this.indexList = indexList;
         this.dutyDate = dutyDate;
     }
 
@@ -45,14 +46,29 @@ public class AssignCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
-        if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        for (Index index : indexList) {
+            if (index.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            }
         }
 
-        Person personToAssign = lastShownList.get(index.getZeroBased());
-        personToAssign.assignDuty(dutyDate);
+        for (Index index : indexList) {
+            lastShownList = model.getFilteredPersonList();
+            Person personToAssign = lastShownList.get(index.getZeroBased());
+            personToAssign.assignDuty(dutyDate);
+        }
+
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
 
+        if (indexList.size() > 1) {
+            long size = indexList.stream()
+                    .map(Index::getOneBased)
+                    .distinct()
+                    .count();
+            return new CommandResult(String.format(MESSAGE_MASS_ASSIGN_DUTY_SUCCESS, size));
+        }
+
+        Person personToAssign = lastShownList.get(indexList.get(0).getZeroBased());
         return new CommandResult(String.format(MESSAGE_ASSIGN_DUTY_SUCCESS, Messages.format(personToAssign)));
     }
 
@@ -66,14 +82,14 @@ public class AssignCommand extends Command {
         if (!(other instanceof AssignCommand temp)) {
             return false;
         } else {
-            return index.equals(temp.index) && dutyDate.equals(temp.dutyDate);
+            return indexList.equals(temp.indexList) && dutyDate.equals(temp.dutyDate);
         }
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this)
-                .add("targetIndex", index)
+                .add("targetIndex", indexList.toString())
                 .add("dutyDate", dutyDate)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -47,7 +47,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_NRIC + "NRIC] "
             + "[" + PREFIX_SALARY + "SALARY] "
             + "[" + PREFIX_COMPANY + "COMPANY] "
-            + "[" + PREFIX_RANK + "RANK] "
+            + "[" + PREFIX_RANK + "RANK] \n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_NAME + "Jane Doe "
             + PREFIX_PHONE + "91234567";

--- a/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AssignCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DUTY;
 
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.commands.AssignCommand;
@@ -20,9 +22,10 @@ public class AssignCommandParser implements Parser<AssignCommand> {
         requireNonNull(userInput);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(userInput, PREFIX_DUTY);
 
-        Index index;
+        List<Index> indexList;
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            String preamble = argMultimap.getPreamble();
+            indexList = ParserUtil.parseIndexList(preamble);
         } catch (IllegalValueException ive) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AssignCommand.MESSAGE_USAGE), ive);
@@ -32,7 +35,7 @@ public class AssignCommandParser implements Parser<AssignCommand> {
 
         if (argMultimap.getValue(PREFIX_DUTY).isPresent()) {
             String dutyDate = ParserUtil.parseDuty(argMultimap.getValue(PREFIX_DUTY).get());
-            return new AssignCommand(index, dutyDate);
+            return new AssignCommand(indexList, dutyDate);
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AssignCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,6 +35,24 @@ public class ParserUtil {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+    }
+
+    /**
+     * Parses a space-separated {@code oneBasedIndexes} into a list of {@code Index} objects and returns it.
+     * Leading and trailing whitespaces will be trimmed. Each individual index in the string will be validated and
+     * parsed using the {@link #parseIndex(String)} method.
+     *
+     * @param oneBasedIndexes A string containing one or more space-separated one-based indexes to be parsed.
+     * @return A list of {@code Index} objects corresponding to the parsed one-based indexes.
+     * @throws ParseException if any of the specified indexes are invalid (not non-zero unsigned integers).
+     */
+    public static List<Index> parseIndexList(String oneBasedIndexes) throws ParseException {
+        List<String> indexArray = List.of(oneBasedIndexes.trim().split("\\s+"));
+        List<Index> indexList = new ArrayList<>();
+        for (String index : indexArray) {
+            indexList.add(parseIndex(index));
+        }
+        return List.copyOf(indexList);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnassignCommandTest.java
@@ -93,7 +93,7 @@ public class UnassignCommandTest {
         dutyListSecond.addAll(personToAssignSecond.getDuty().getDutyList());
         dutyListFirst.remove(nextTwoMonthDate);
         dutyListSecond.remove(nextTwoMonthDate);
-        Person unassignedPersonFirst= new PersonBuilder(personToUnassignFirst).withDuty(dutyListFirst).build();
+        Person unassignedPersonFirst = new PersonBuilder(personToUnassignFirst).withDuty(dutyListFirst).build();
         Person unassignedPersonSecond = new PersonBuilder(personToAssignSecond).withDuty(dutyListSecond).build();
 
         String expectedMessageFirst = String.format(UnassignCommand.MESSAGE_UNASSIGN_DUTY_SUCCESS,

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -93,7 +93,7 @@ public class AddressBookParserTest {
         AssignCommand command = (AssignCommand) parser.parseCommand(
                 AssignCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased() + " "
                         + CliSyntax.PREFIX_DUTY + validDate);
-        assertEquals(new AssignCommand(INDEX_FIRST_PERSON, validDate), command);
+        assertEquals(new AssignCommand(List.of(INDEX_FIRST_PERSON), validDate), command);
     }
 
     @Test public void parseCommand_unassign() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AssignCommandParserTest.java
@@ -10,6 +10,8 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
@@ -43,10 +45,16 @@ public class AssignCommandParserTest {
         assertParseFailure(parser, "0" + DUTY_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 some random string" + DUTY_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "1 i/ string" + DUTY_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // invalid indexes
+        assertParseFailure(parser, "1 0" + DUTY_DESC_AMY, MESSAGE_INVALID_FORMAT);
+
+        // commas in indexes
+        assertParseFailure(parser, "1, 2" + DUTY_DESC_AMY, MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -57,15 +65,15 @@ public class AssignCommandParserTest {
 
     @Test
     public void parse_success() {
-        Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + DUTY_DESC_AMY;
-        AssignCommand expectedCommand = new AssignCommand(targetIndex, VALID_DUTY_AMY_STRING);
+        List<Index> targetIndexList = List.of(INDEX_FIRST_PERSON);
+        String userInput = INDEX_FIRST_PERSON.getOneBased() + DUTY_DESC_AMY;
+        AssignCommand expectedCommand = new AssignCommand(targetIndexList, VALID_DUTY_AMY_STRING);
 
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        Index secondTargetIndex = INDEX_SECOND_PERSON;
-        String secondUserInput = secondTargetIndex.getOneBased() + DUTY_DESC_AMY;
-        AssignCommand secondExpectedCommand = new AssignCommand(secondTargetIndex, VALID_DUTY_AMY_STRING);
+        targetIndexList = List.of(INDEX_SECOND_PERSON);
+        String secondUserInput = INDEX_SECOND_PERSON.getOneBased() + DUTY_DESC_AMY;
+        AssignCommand secondExpectedCommand = new AssignCommand(targetIndexList, VALID_DUTY_AMY_STRING);
         assertParseSuccess(parser, secondUserInput, secondExpectedCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -44,6 +47,35 @@ public class ParserUtilTest {
 
         // Leading and trailing whitespaces
         assertEquals(INDEX_FIRST_PERSON, ParserUtil.parseIndex("  1  "));
+    }
+
+    @Test
+    public void parseIndexList_invalidInput_throwsParseException() {
+        // Parse 1 valid index and 1 invalid index
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndexList("10 a"));
+
+        // Parse 1 invalid index
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndexList("a"));
+
+        // Parse 2 valid with commas
+        assertThrows(ParseException.class, () -> ParserUtil.parseIndexList("1, 2"));
+    }
+
+    @Test
+    public void parseIndexList_outOfRangeInput_throwsParseException() {
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
+                -> ParserUtil.parseIndexList(Long.toString(Integer.MAX_VALUE + 1)));
+    }
+
+    @Test
+    public void parseIndexList_validInput_success() throws Exception {
+        // No whitespaces
+        assertEquals(List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON),
+                ParserUtil.parseIndexList("1 2"));
+
+        // Leading and trailing whitespaces
+        assertEquals(List.of(INDEX_FIRST_PERSON, INDEX_SECOND_PERSON),
+                ParserUtil.parseIndexList("  1  2    "));
     }
 
     @Test


### PR DESCRIPTION
## Enhancements  
- Added functionality to mass assign multiple personnel to a single duty date.  
- Updated `ParserUtil` class: Added `parseIndexList` method to process multiple indexes and return a `List<Index>`.  
- Modified `assign` command to accept a `List<Index>` for bulk personnel assignment.  

## Command Update  
- **Previous**:  `assign 1 d/2025-03-03` (Assigns personnel displayed at index 1 to duty on March 3, 2025).
- **Now**: `assign 1 2 3 d/2025-03-03` (Assigns 3 personnel displayed at index 1, 2, 3 to duty on March 3, 2025).
- **Note**: Indexes are separated by spaces.

Closes #65 