### PR TITLE
Fix application crashing bug

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -100,7 +100,15 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(Nric.MESSAGE_CONSTRAINTS);
         }
         final Nric modelNric = new Nric(nric);
-
+ 
+         if (duty == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Duty.class.getSimpleName()));
+        }
+        for (String date : duty.getDutyList()) {
+            if (!Duty.isValidDate(date)) {
+                throw new IllegalValueException(Duty.MESSAGE_CONSTRAINTS);
+            }
+        }
         final Duty modelDuty = duty.toModelType();
 
         if (salary == null) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -100,8 +100,8 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(Nric.MESSAGE_CONSTRAINTS);
         }
         final Nric modelNric = new Nric(nric);
- 
-         if (duty == null) {
+
+        if (duty == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Duty.class.getSimpleName()));
         }
         for (String date : duty.getDutyList()) {

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -5,11 +5,14 @@ import static seedu.address.storage.JsonAdaptedPerson.MISSING_FIELD_MESSAGE_FORM
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
+import java.util.Arrays;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Company;
+import seedu.address.model.person.Duty;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
@@ -21,6 +24,9 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_NRIC = "Axxxx123A";
+    private static final JsonAdaptedDuty INVALID_JSON_DUTY = new JsonAdaptedDuty(
+        Arrays.asList("2025-04--15", "2025-03-01", "2024-03-02", "2024-02-29", "2023-03-03")
+    );
     private static final String INVALID_SALARY = "10";
     private static final String INVALID_COMPANY = "123";
     private static final String INVALID_RANK = "ABCD";
@@ -109,6 +115,24 @@ public class JsonAdaptedPersonTest {
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_ADDRESS, null, VALID_JSON_DUTY,
                 VALID_SALARY, VALID_COMPANY, VALID_RANK);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Nric.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidDuty_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_NRIC, INVALID_JSON_DUTY,
+                VALID_SALARY, VALID_COMPANY, VALID_RANK);
+        String expectedMessage = Duty.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullDuty_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_NRIC, null,
+                VALID_SALARY, VALID_COMPANY, VALID_RANK);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Duty.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 


### PR DESCRIPTION
Program crashes when invalid date is edited in .json file for Duty.

The program couldn't handle the error gracefully and the application couldn't start.

JsonAdaptedPerson.java toModelType() function is modified to handle the issue gracefully. The function checks for the validity of the dates and throws exception if the dates are invalid.

Fixed proof:
![image](https://github.com/user-attachments/assets/74ca737f-1aa0-4082-8bef-86e755e9dd99)

**Status**: Ready to merge (after review)
