### PR TITLE
Make NRIC error message more comprehensive

### DIFF
--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -10,8 +10,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Nric {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "NRIC should start with S or T, followed by xxxx, 3 digit number and ends with an alphabet"
-                    + " and it should not be blank";
+            "NRIC should start with S or T, followed by xxxx,"
+                + " 3 digit number and ends with an alphabet in capital letter"
+                + " and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,


### PR DESCRIPTION
The error message when adding a contact with an invalid NRIC sometimes does not match the actual issue.

When entered the following command:
`add n/aam p/99990000 a/asd nr/Txxxx000a s/100 c/ALPHA r/COL`

the error message displayed used to be:
`NRIC should start with S or T, followed by xxxx, 3 digit number and ends with an alphabet and it should not be blank`

The error message should also state that the last character of the NRIC must be a capital letter.

After fix, the message now display:
`NRIC should start with S or T, followed by xxxx, 3 digit number and ends with an alphabet in capital letter and it should not be blank`

User can now better know what their error is with this small change in the error message.

Fixed proof:
![image](https://github.com/user-attachments/assets/5140455d-e988-46d9-a7ab-6a870c7c80e4)

Status: Ready to merge (after review)
