### PR TITLE
Fix rank field bugs

### DIFF
--- a/src/main/java/seedu/address/model/person/Rank.java
+++ b/src/main/java/seedu/address/model/person/Rank.java
@@ -10,12 +10,12 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Rank {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Rank should contain exactly 3 alphanumeric characters, and it should not be blank";
+            "Rank should contain 2-4 alphanumeric characters in capital letters, and it should not be blank";
 
     /*
-     * The rank must contain exactly 3 alphanumeric characters.
+     * The rank must contain 2-4 alphanumeric characters in capital letters.
      */
-    public static final String VALIDATION_REGEX = "[A-Z0-9]{3}";
+    public static final String VALIDATION_REGEX = "[A-Z0-9]{2,4}";
 
     public final String fullRank;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -78,7 +78,7 @@ public class CommandTestUtil {
     public static final String INVALID_NRIC_DESC = " " + PREFIX_NRIC + "Axxxx123A"; // 'A' not allowed in NRIC starting
     public static final String INVALID_SALARY_DESC = " " + PREFIX_SALARY + "50"; // Salary must be at least 100
     public static final String INVALID_COMPANY_DESC = " " + PREFIX_COMPANY + "0123"; // Company cannot have numbers
-    public static final String INVALID_RANK_DESC = " " + PREFIX_RANK + "ABCD"; // Rank can only have 3 letters
+    public static final String INVALID_RANK_DESC = " " + PREFIX_RANK + "ABCDE"; // Rank can only have 2-4 letters
     public static final String INVALID_DUTY_DESC = " " + PREFIX_DUTY + "26/11/2025"; // valid format is yyyy-mm-dd
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/address/model/person/RankTest.java
+++ b/src/test/java/seedu/address/model/person/RankTest.java
@@ -29,11 +29,13 @@ public class RankTest {
         assertFalse(Rank.isValidRank(" ")); // spaces only
         assertFalse(Rank.isValidRank("^")); // only non-alphanumeric characters
         assertFalse(Rank.isValidRank("SG*")); // contains non-alphanumeric characters
-        assertFalse(Rank.isValidRank("3SGT")); // More than 3 characters (invalid)
+        assertFalse(Rank.isValidRank("SGTCR")); // More than 4 characters (invalid)
         assertFalse(Rank.isValidRank("S")); // Less than 3 characters (invalid)
 
         // valid rank
         assertTrue(Rank.isValidRank("CPL")); // alphabets only
+        assertTrue(Rank.isValidRank("BG")); // 2 letter alphabets only
+        assertTrue(Rank.isValidRank("SLTC")); // 4 letter alphabets only
         assertTrue(Rank.isValidRank("123")); // numbers only
         assertTrue(Rank.isValidRank("3SG")); // alphanumeric characters
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -23,7 +23,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_NRIC = "Axxxx123A";
     private static final String INVALID_SALARY = "10";
     private static final String INVALID_COMPANY = "123";
-    private static final String INVALID_RANK = "ABCD";
+    private static final String INVALID_RANK = "ABCDE";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();


### PR DESCRIPTION
Rank only accepts 3 alphanumerical capital letters

Some ranks contains only 2 or 4 letters

What changed:
1) Requirements for the rank field is changed
2) Error message is updated to be more comprehensive

Closes issue:
#130 
#162
#164 
#174 